### PR TITLE
removed unneeded double `<`

### DIFF
--- a/app/routes/docs.dropdown.jsx
+++ b/app/routes/docs.dropdown.jsx
@@ -435,7 +435,7 @@ export default function Dropdown() {
             </nav>
             <Code as="footer">{`<nav>
   <ul>
-    <li><strong>Acme Corp<</strong></li>
+    <li><strong>Acme Corp</strong></li>
   </ul>
   <ul>
     <li><a href="#" class="secondary">Services</a></li>

--- a/app/routes/docs.nav.jsx
+++ b/app/routes/docs.nav.jsx
@@ -336,7 +336,7 @@ export default function Nav() {
             </nav>
             <Code as="footer">{`<nav>
   <ul>
-    <li><strong>Acme Corp<</strong></li>
+    <li><strong>Acme Corp</strong></li>
   </ul>
   <ul>
     <li><a href="#" class="secondary">Services</a></li>


### PR DESCRIPTION
Barely noticeable, unless you're using the copy/paste function. 😉 