### PR TITLE
Fix a code example

### DIFF
--- a/app/routes/docs.modal.jsx
+++ b/app/routes/docs.modal.jsx
@@ -192,7 +192,7 @@ export default function Modal() {
       <li>Price: $10</li>
     </ul>
     <footer>
-      <button className="secondary">
+      <button class="secondary">
         Cancel
       </button>
       <button>Confirm</button>


### PR DESCRIPTION
An example of code contains:

```html
<button className="secondary">
  Cancel
</button>
```

This code should use `class` instead of `className`:

```html
<button class="secondary">
  Cancel
</button>
```