### PR TITLE
Fix: Removed CSS Grid Generator as it doesn't exist anymore

### DIFF
--- a/app/routes/docs.grid.jsx
+++ b/app/routes/docs.grid.jsx
@@ -122,8 +122,7 @@ export default function Grid() {
           <p>
             If you need a light and custom grid, you can look at{" "}
             <strong>CSS Grid Generators</strong>—for example,{" "}
-            <a href="https://cssgrid-generator.netlify.com/">CSS Grid Generator</a>,{" "}
-            <a href="http://grid.layoutit.com/">Layoutit!</a>, or{" "}
+            <a href="http://grid.layoutit.com/">Layoutit!</a> or{" "}
             <a href="https://griddy.io/">Griddy</a>.
           </p>
           <p>


### PR DESCRIPTION
Trying to access the link in the docs leads to the following message:

```
Site Not Found
Looks like you've followed a broken link or entered a URL that doesn't exist on Netlify.

If this is your site, and you weren't expecting a 404 for this path, please visit Netlify's "page not found" support guide for troubleshooting tips.

Netlify Internal ID: 01HX7R02R06MAP92ZYMTXC94M6
```