### PR TITLE
fix link in docs.grid.jsx

### DIFF
--- a/app/routes/docs.grid.jsx
+++ b/app/routes/docs.grid.jsx
@@ -122,7 +122,7 @@ export default function Grid() {
           <p>
             If you need a light and custom grid, you can look at{" "}
             <strong>CSS Grid Generators</strong>—for example,{" "}
-            <a href="https://cssgrid-generator.netlify.com/">CSS Grid Generator</a>,{" "}
+            <a href="https://cssgrid-generator.netlify.app/">CSS Grid Generator</a>,{" "}
             <a href="http://grid.layoutit.com/">Layoutit!</a>, or{" "}
             <a href="https://griddy.io/">Griddy</a>.
           </p>


### PR DESCRIPTION
in https://picocss.com/docs/grid, there is a link to

https://cssgrid-generator.netlify.com/

which is 404. the correct link is

https://cssgrid-generator.netlify.app/

(i.e. `.app` instead of `.com`)

cheers