### PR TITLE
Fix Fuchia typo

### DIFF
--- a/app/routes/docs.version-picker.fuchsia.jsx
+++ b/app/routes/docs.version-picker.fuchsia.jsx
@@ -2,7 +2,7 @@ import ThemePreview from "~/components/docs/ThemePreview";
 import cssStyle from "~/styles/css/custom-themes/fuchsia.css";
 import { themeGeneratorDescription, themeGeneratorTitle } from "~/utils";
 
-const colorName = "Fuchia";
+const colorName = "Fuchsia";
 
 export const meta = () => [
   { title: themeGeneratorTitle(colorName) },


### PR DESCRIPTION
I was checking out the different styles available and couldn't figure out why Fuchsia wasn't loading in properly. Eventually I noticed a typo in the documentation. I believe my small patch should fix the issue so the examples in the documentation will work properly.