### PR TITLE
docs: fix SCSS import

### DIFF
--- a/app/routes/docs._index.jsx
+++ b/app/routes/docs._index.jsx
@@ -117,7 +117,7 @@ export default function QuickStart() {
             <Link to="https://sass-lang.com/documentation/at-rules/use">@use</Link>:
           </p>
           <Code language="scss" className="small">
-            @use "pico";
+            @use "@picocss/pico";
           </Code>
           <p>
             Learn more about the <Link to="/docs/sass">customization with Sass</Link>.


### PR DESCRIPTION
Updates the SCSS import in the Quick start docs to import pico from `@picocss/pico` to fix a stylesheet not found error