### PR TITLE
Address Deprecation Warning for `mixed-decls`

### DIFF
--- a/app/styles/scss/commons/content/_code.scss
+++ b/app/styles/scss/commons/content/_code.scss
@@ -100,6 +100,11 @@ article footer.code {
 
 // Standalone code blocks
 .code:not(article footer.code) {
+  margin-bottom: var(#{$css-var-prefix}block-spacing-vertical);
+  overflow: hidden;
+  border-radius: var(#{$css-var-prefix}border-radius);
+  box-shadow: var(#{$css-var-prefix}card-box-shadow);
+  
   @each $key, $values in $breakpoints {
     @if $values {
       @media (min-width: map.get($values, "breakpoint")) {
@@ -126,10 +131,6 @@ article footer.code {
       }
     }
   }
-  margin-bottom: var(#{$css-var-prefix}block-spacing-vertical);
-  overflow: hidden;
-  border-radius: var(#{$css-var-prefix}border-radius);
-  box-shadow: var(#{$css-var-prefix}card-box-shadow);
 
   pre {
     padding: calc(var(#{$css-var-prefix}block-spacing-vertical) * 0.66)

--- a/app/styles/scss/landings/layout/_landmarks.scss
+++ b/app/styles/scss/landings/layout/_landmarks.scss
@@ -3,6 +3,7 @@
 
 #{$semantic-root-element} {
   overflow: hidden;
+  padding: 0;
 
   > main {
     #{$css-var-prefix}homepage-spacing-vertical: calc(var(#{$css-var-prefix}spacing) * 5);
@@ -38,7 +39,6 @@
         }
       }
     }
-    padding: 0;
 
     &.is-loading {
       animation-duration: 1s;


### PR DESCRIPTION
Addresses the below deprecation warning:

```
    ╷
105 │ ┌       @media (min-width: map.get($values, "breakpoint")) {
106 │ │         $multiplier: 1;
107 │ │ 
108 │ │         @if $key == "sm" {
109 │ │           $multiplier: 1.25;
110 │ │         } @else if $key == "md" {
111 │ │           $multiplier: 1.5;
112 │ │         } @else if $key == "lg" {
113 │ │           $multiplier: 1.75;
114 │ │         } @else if $key == "xl" {
115 │ │           $multiplier: 2;
116 │ │         } @else if $key == "xxl" {
117 │ │           $multiplier: 2.5;
118 │ │         }
119 │ │ 
120 │ │         #{$css-var-prefix}block-spacing-horizontal: calc(
121 │ │           var(#{$css-var-prefix}spacing) * $multiplier
122 │ │         );
123 │ │         #{$css-var-prefix}block-spacing-vertical: calc(
124 │ │           var(#{$css-var-prefix}spacing) * $multiplier
125 │ │         );
126 │ │       }
    │ └─── nested rule
... │
129 │     margin-bottom: var(#{$css-var-prefix}block-spacing-vertical);
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    node_modules/.pnpm/@picocss+picocss.com@https+++codeload.github.com+picocss+picocss.com+tar.gz+c6864890939_07d1bd08f193b1a3dfd219129dd6c019/node_modules/@picocss/picocss.com/app/styles/scss/commons/content/_code.scss 129:3  @use
    node_modules/.pnpm/@picocss+picocss.com@https+++codeload.github.com+picocss+picocss.com+tar.gz+c6864890939_07d1bd08f193b1a3dfd219129dd6c019/node_modules/@picocss/picocss.com/app/styles/scss/main.scss 15:1                    @use
    src/styles/global.scss 1:1                                                                                                                                                                                                      root stylesheet

Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
``` 