### PR TITLE
Address Deprecation Warning for `global-builtin`

### DIFF
--- a/app/styles/scss/commons/theme/default/_dark.scss
+++ b/app/styles/scss/commons/theme/default/_dark.scss
@@ -1,9 +1,10 @@
-@use "colors" as *;
-@use "settings" as *;
+@use "sass:color";
+@use "@picocss/pico/scss/colors" as *;
+@use "@picocss/pico/scss/settings" as *;
 
 @mixin theme {
   // Header
-  #{$css-var-prefix}header-background: #{rgba(mix($slate-950, $slate-900), 0.9)};
+  #{$css-var-prefix}header-background: #{rgba(color.mix($slate-950, $slate-900), 0.9)};
   #{$css-var-prefix}header-border-color: rgba($slate-850, 0.9);
 
   // Logo
@@ -12,7 +13,7 @@
   #{$css-var-prefix}logo-big-sparkle: #{$amber-200};
 
   // Current version checkmark
-  #{$css-var-prefix}current-version-checkmark: #{mix($jade-450, $zinc-200)};
+  #{$css-var-prefix}current-version-checkmark: #{color.mix($jade-450, $zinc-200)};
 
   // Card for components
   #{$css-var-prefix}card-component-outline-width: 2px;
@@ -20,11 +21,11 @@
 
   // Code
   #{$css-var-prefix}code-color: #{$zinc-350};
-  #{$css-var-prefix}code-tag: #{mix($zinc-350, $amber-350, 25%)};
-  #{$css-var-prefix}code-attr: #{mix($zinc-350, $fuchsia-350, 50%)};
-  #{$css-var-prefix}code-value: #{mix($zinc-350, $jade-350, 75%)};
+  #{$css-var-prefix}code-tag: #{color.mix($zinc-350, $amber-350, 25%)};
+  #{$css-var-prefix}code-attr: #{color.mix($zinc-350, $fuchsia-350, 50%)};
+  #{$css-var-prefix}code-value: #{color.mix($zinc-350, $jade-350, 75%)};
   #{$css-var-prefix}code-comment: #{$zinc-500};
-  #{$css-var-prefix}code-copied: #{mix($jade-450, $zinc-200)};
+  #{$css-var-prefix}code-copied: #{color.mix($jade-450, $zinc-200)};
 
   // Chapter
   #{$css-var-prefix}chapter-color: var(#{$css-var-prefix}code-tag);

--- a/app/styles/scss/commons/theme/default/_dark.scss
+++ b/app/styles/scss/commons/theme/default/_dark.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
-@use "@picocss/pico/scss/colors" as *;
-@use "@picocss/pico/scss/settings" as *;
+@use "colors" as *;
+@use "settings" as *;
 
 @mixin theme {
   // Header

--- a/app/styles/scss/commons/theme/default/_light.scss
+++ b/app/styles/scss/commons/theme/default/_light.scss
@@ -1,5 +1,6 @@
-@use "colors" as *;
-@use "settings" as *;
+@use "sass:color";
+@use "@picocss/pico/scss/colors" as *;
+@use "@picocss/pico/scss/settings" as *;
 
 @mixin theme {
   // Header
@@ -12,7 +13,7 @@
   #{$css-var-prefix}logo-big-sparkle: #{$pumpkin-300};
 
   // Current version checkmark
-  #{$css-var-prefix}current-version-checkmark: #{mix($jade-450, $zinc-750)};
+  #{$css-var-prefix}current-version-checkmark: #{color.mix($jade-450, $zinc-750)};
 
   // Card for components
   #{$css-var-prefix}card-component-outline-width: 0;
@@ -21,10 +22,10 @@
   // Code
   #{$css-var-prefix}code-color: #{$zinc-600};
   #{$css-var-prefix}code-tag: #{$pumpkin-600};
-  #{$css-var-prefix}code-attr: #{mix($zinc-600, $fuchsia-600, 25%)};
-  #{$css-var-prefix}code-value: #{mix($zinc-600, $jade-600, 50%)};
+  #{$css-var-prefix}code-attr: #{color.mix($zinc-600, $fuchsia-600, 25%)};
+  #{$css-var-prefix}code-value: #{color.mix($zinc-600, $jade-600, 50%)};
   #{$css-var-prefix}code-comment: #{$zinc-450};
-  #{$css-var-prefix}code-copied: #{mix($jade-450, $zinc-750)};
+  #{$css-var-prefix}code-copied: #{color.mix($jade-450, $zinc-750)};
 
   // Chapter
   #{$css-var-prefix}chapter-color: var(#{$css-var-prefix}code-tag);

--- a/app/styles/scss/commons/theme/default/_light.scss
+++ b/app/styles/scss/commons/theme/default/_light.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
-@use "@picocss/pico/scss/colors" as *;
-@use "@picocss/pico/scss/settings" as *;
+@use "colors" as *;
+@use "settings" as *;
 
 @mixin theme {
   // Header

--- a/app/styles/scss/docs/theme/default/_dark.scss
+++ b/app/styles/scss/docs/theme/default/_dark.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "colors" as *;
 @use "settings" as *;
 
@@ -6,9 +7,9 @@
   #{$css-var-prefix}aside-link-current-background-color: #{$slate-850};
 
   // Color coded scale
-  #{$css-var-prefix}scale-color-1: #{mix($jade-150, $zinc-200)};
-  #{$css-var-prefix}scale-color-2: #{mix($lime-150, $zinc-200)};
-  #{$css-var-prefix}scale-color-3: #{mix($amber-250, $zinc-200)};
-  #{$css-var-prefix}scale-color-4: #{mix($pumpkin-250, $zinc-200)};
-  #{$css-var-prefix}scale-color-5: #{mix($red-350, $zinc-200)};
+  #{$css-var-prefix}scale-color-1: #{color.mix($jade-150, $zinc-200)};
+  #{$css-var-prefix}scale-color-2: #{color.mix($lime-150, $zinc-200)};
+  #{$css-var-prefix}scale-color-3: #{color.mix($amber-250, $zinc-200)};
+  #{$css-var-prefix}scale-color-4: #{color.mix($pumpkin-250, $zinc-200)};
+  #{$css-var-prefix}scale-color-5: #{color.mix($red-350, $zinc-200)};
 }

--- a/app/styles/scss/docs/theme/default/_light.scss
+++ b/app/styles/scss/docs/theme/default/_light.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "colors" as *;
 @use "settings" as *;
 
@@ -18,7 +19,7 @@
       #{$css-var-prefix}card-background-color: #{$slate-900};
       #{$css-var-prefix}card-border-color: var(#{$css-var-prefix}card-background-color);
       #{$css-var-prefix}card-box-shadow: var(#{$css-var-prefix}box-shadow);
-      #{$css-var-prefix}card-sectioning-background-color: #{mix($slate-900, $slate-850)};
+      #{$css-var-prefix}card-sectioning-background-color: #{color.mix($slate-900, $slate-850)};
     }
   }
 }

--- a/app/styles/scss/landings/theme/default/_dark.scss
+++ b/app/styles/scss/landings/theme/default/_dark.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "colors" as *;
 @use "settings" as *;
 
@@ -5,52 +6,52 @@
   // Demo border gradient
   #{$css-var-prefix}demo-border-gradient-colors:
     transparent 33%,
-    mix($azure-800, $fuchsia-800, 20%),
-    mix($azure-800, $purple-800, 25%),
-    mix($azure-800, $violet-800, 30%),
-    mix($azure-800, $indigo-800, 35%);
+    color.mix($azure-800, $fuchsia-800, 20%),
+    color.mix($azure-800, $purple-800, 25%),
+    color.mix($azure-800, $violet-800, 30%),
+    color.mix($azure-800, $indigo-800, 35%);
 
   // Cards
   #{$css-var-prefix}card-box-shadow: none;
-  #{$css-var-prefix}card-background-color: #{mix($slate-950, $slate-900, 25%)};
+  #{$css-var-prefix}card-background-color: #{color.mix($slate-950, $slate-900, 25%)};
   #{$css-var-prefix}card-component-outline-width: 0.0625rem;
-  #{$css-var-prefix}card-component-outline-color: #{mix($slate-900, $slate-850)};
+  #{$css-var-prefix}card-component-outline-color: #{color.mix($slate-900, $slate-850)};
   #{$css-var-prefix}card-border-color: var(#{$css-var-prefix}card-component-outline-color);
 
   // Mark gradient
   #{$css-var-prefix}mark-gradient: linear-gradient(
     to right,
-    mix($azure-300, $fuchsia-300, 20%),
-    mix($azure-300, $purple-300, 25%),
-    mix($azure-300, $violet-300, 30%),
-    mix($azure-300, $indigo-300, 35%)
+    color.mix($azure-300, $fuchsia-300, 20%),
+    color.mix($azure-300, $purple-300, 25%),
+    color.mix($azure-300, $violet-300, 30%),
+    color.mix($azure-300, $indigo-300, 35%)
   );
 
   // Stats color
-  #{$css-var-prefix}stats-color: mix($azure-300, $slate-300);
+  #{$css-var-prefix}stats-color: color.mix($azure-300, $slate-300);
 
   // Features icon color
-  #{$css-var-prefix}features-icon-color: mix($azure-300, $purple-300, 25%);
+  #{$css-var-prefix}features-icon-color: color.mix($azure-300, $purple-300, 25%);
 
   // Comparison gradients
   #{$css-var-prefix}comparison-gradient-valid: linear-gradient(
     var(#{$css-var-prefix}comparison-gradient-direction, to bottom),
-    mix($cyan-500, $slate-500, 25%),
-    mix($jade-550, $slate-550, 37.5%),
-    mix($green-600, $slate-600, 50%)
+    color.mix($cyan-500, $slate-500, 25%),
+    color.mix($jade-550, $slate-550, 37.5%),
+    color.mix($green-600, $slate-600, 50%)
   );
   #{$css-var-prefix}comparison-gradient-invalid: linear-gradient(
     var(#{$css-var-prefix}comparison-gradient-direction, to bottom),
-    mix($pumpkin-500, $slate-500, 50%),
-    mix($orange-550, $slate-550, 62.5%),
-    mix($red-600, $slate-600, 75%)
+    color.mix($pumpkin-500, $slate-500, 50%),
+    color.mix($orange-550, $slate-550, 62.5%),
+    color.mix($red-600, $slate-600, 75%)
   );
 
   // Language badges
-  $html-color: mix($orange-300, $slate-300, 75%);
-  $react-color: mix(mix($azure-300, $cyan-300, 25%), $slate-400);
-  $sass-color: mix($fuchsia-300, $slate-300);
-  $javascript-color: mix($amber-300, $slate-300);
+  $html-color: color.mix($orange-300, $slate-300, 75%);
+  $react-color: color.mix(color.mix($azure-300, $cyan-300, 25%), $slate-400);
+  $sass-color: color.mix($fuchsia-300, $slate-300);
+  $javascript-color: color.mix($amber-300, $slate-300);
   $css-color: $blue-300;
   $background-color-opacity: 0.125;
   #{$css-var-prefix}badge-html-background-color: rgba($html-color, $background-color-opacity);

--- a/app/styles/scss/landings/theme/default/_light.scss
+++ b/app/styles/scss/landings/theme/default/_light.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "colors" as *;
 @use "settings" as *;
 
@@ -5,10 +6,10 @@
   // Demo border gradient
   #{$css-var-prefix}demo-border-gradient-colors:
     transparent 33%,
-    mix($azure-150, $fuchsia-150, 25%),
-    mix($azure-150, $purple-150, 30%),
-    mix($azure-150, $violet-150, 35%),
-    mix($azure-150, $indigo-150, 40%);
+    color.mix($azure-150, $fuchsia-150, 25%),
+    color.mix($azure-150, $purple-150, 30%),
+    color.mix($azure-150, $violet-150, 35%),
+    color.mix($azure-150, $indigo-150, 40%);
 
   // Cards
   #{$css-var-prefix}card-box-shadow: var(#{$css-var-prefix}box-shadow);
@@ -18,37 +19,37 @@
   // Mark gradient
   #{$css-var-prefix}mark-gradient: linear-gradient(
     to right,
-    mix($slate-650, $fuchsia-650, 25%),
-    mix($slate-650, $purple-650, 30%),
-    mix($slate-650, $violet-650, 35%),
-    mix($slate-650, $indigo-650, 40%)
+    color.mix($slate-650, $fuchsia-650, 25%),
+    color.mix($slate-650, $purple-650, 30%),
+    color.mix($slate-650, $violet-650, 35%),
+    color.mix($slate-650, $indigo-650, 40%)
   );
 
   // Stats color
-  #{$css-var-prefix}stats-color: mix($azure-600, $slate-600);
+  #{$css-var-prefix}stats-color: color.mix($azure-600, $slate-600);
 
   // Features icon color
-  #{$css-var-prefix}features-icon-color: mix($slate-550, $purple-550, 30%);
+  #{$css-var-prefix}features-icon-color: color.mix($slate-550, $purple-550, 30%);
 
   // Comparison gradients
   #{$css-var-prefix}comparison-gradient-valid: linear-gradient(
     var(#{$css-var-prefix}comparison-gradient-direction, to bottom),
-    mix($cyan-300, $slate-300, 25%),
-    mix($jade-350, $slate-350, 37.5%),
-    mix($green-400, $slate-400, 50%)
+    color.mix($cyan-300, $slate-300, 25%),
+    color.mix($jade-350, $slate-350, 37.5%),
+    color.mix($green-400, $slate-400, 50%)
   );
   #{$css-var-prefix}comparison-gradient-invalid: linear-gradient(
     var(#{$css-var-prefix}comparison-gradient-direction, to bottom),
-    mix($pumpkin-300, $slate-300, 50%),
-    mix($orange-350, $slate-350, 62.5%),
-    mix($red-400, $slate-400, 75%)
+    color.mix($pumpkin-300, $slate-300, 50%),
+    color.mix($orange-350, $slate-350, 62.5%),
+    color.mix($red-400, $slate-400, 75%)
   );
 
   // Language badges
   $html-color: $orange-600;
-  $react-color: mix(mix($azure-600, $cyan-600), $slate-400, 75%);
-  $sass-color: mix($fuchsia-600, $slate-600, 75%);
-  $javascript-color: mix($amber-600, $pumpkin-600);
+  $react-color: color.mix(color.mix($azure-600, $cyan-600), $slate-400, 75%);
+  $sass-color: color.mix($fuchsia-600, $slate-600, 75%);
+  $javascript-color: color.mix($amber-600, $pumpkin-600);
   $css-color: $blue-600;
   $background-color-opacity: 0.125;
   #{$css-var-prefix}badge-html-background-color: rgba($html-color, $background-color-opacity);


### PR DESCRIPTION
Addresses warnings like:

```
   ╷
15 │   #{$css-var-prefix}current-version-checkmark: #{mix($jade-450, $zinc-750)};
   │                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/.pnpm/@picocss+picocss.com@https+++codeload.github.com+picocss+picocss.com+tar.gz+c6864890939_993ae236b4494a641ef7a87e2ca7e199/node_modules/@picocss/picocss.com/app/styles/scss/commons/theme/default/_light.scss 15:50  theme()
    node_modules/.pnpm/@picocss+picocss.com@https+++codeload.github.com+picocss+picocss.com+tar.gz+c6864890939_993ae236b4494a641ef7a87e2ca7e199/node_modules/@picocss/picocss.com/app/styles/scss/commons/theme/_default.scss 21:3         @use
    node_modules/.pnpm/@picocss+picocss.com@https+++codeload.github.com+picocss+picocss.com+tar.gz+c6864890939_993ae236b4494a641ef7a87e2ca7e199/node_modules/@picocss/picocss.com/app/styles/scss/main.scss 7:1                            @use
    src/styles/global.scss 1:1                                                                                                                                                                                                             root stylesheet

Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import
```